### PR TITLE
feat(base): generate the description meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ path = "MODULE_PATH"
 
 ### Base
 
-Set the `lang` and `dir` attributes on `<html>`.
+1. Set the `lang` and `dir` attributes on `<html>` (HugoPress only).
+2. Generate the description meta tag.
 
-| Path                                             | Partial |
-| ------------------------------------------------ | ------- |
-| `github.com/razonyang/hugo-mod-seo/modules/base` | -       |
+| Path                                             | Partial                  |
+| ------------------------------------------------ | ------------------------ |
+| `github.com/razonyang/hugo-mod-seo/modules/base` | `seo/modules/base/index` |
 
 ### Alternatives
 

--- a/modules/base/hugo.toml
+++ b/modules/base/hugo.toml
@@ -2,3 +2,5 @@
 path = "github.com/razonyang/hugopress"
 
 [params.hugopress.modules.seo-base.attributes.document]
+
+[params.hugopress.modules.seo-base.hooks.head-begin]

--- a/modules/base/layouts/partials/hugopress/modules/seo-base/hooks/head-begin.html
+++ b/modules/base/layouts/partials/hugopress/modules/seo-base/hooks/head-begin.html
@@ -1,0 +1,1 @@
+{{- partial "seo/modules/base/index" .Page -}}

--- a/modules/base/layouts/partials/seo/modules/base/index.html
+++ b/modules/base/layouts/partials/seo/modules/base/index.html
@@ -1,0 +1,7 @@
+{{/* Generate the description meta tag. */}}
+{{- $desc := default .Title (default (.Summary | plainify) .Description) }}
+{{- $descMaxLen := 160 }}
+{{- if gt (len $desc) $descMaxLen }}
+  {{- $desc = substr $desc 0 $descMaxLen }}
+{{- end }}
+<meta name="description" content="{{ $desc }}" />


### PR DESCRIPTION
Description look up order as follows:
1. Page's description parameter
2. Page's summary
3. Page's title